### PR TITLE
Fix TypeScript build error in monthly totals query

### DIFF
--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -290,8 +290,8 @@ export async function getMonthlyTotals() {
         month: curMonth,
         year: curYear,
         monthName,
-        debits: debitResult.rows,
-        credits: creditResult.rows,
+        debits: debitResult.rows as unknown as Array<{ TRAN_TYPE: string; SUM_DEBIT: number }>,
+        credits: creditResult.rows as unknown as Array<{ TRAN_TYPE: string; SUM_CREDIT: number }>,
       });
     }
 


### PR DESCRIPTION
## Summary
- Fixes Vercel build failure caused by TypeScript type mismatch in `getMonthlyTotals()`
- Casts `query()` result rows to the expected typed arrays for debits and credits

## Test plan
- [ ] Vercel build passes without TypeScript errors
- [ ] Monthly totals page still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)