### PR TITLE
Fix login redirect on Vercel

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { signIn } from "next-auth/react";
-import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -12,7 +11,6 @@ import {
 } from "@/components/ui/card";
 
 export default function LoginPage() {
-  const router = useRouter();
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
@@ -33,8 +31,7 @@ export default function LoginPage() {
     if (result?.error) {
       setError("Invalid username or password");
     } else {
-      router.push("/balance-sheet");
-      router.refresh();
+      window.location.href = "/balance-sheet";
     }
   }
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,6 +2,7 @@ import NextAuth from "next-auth";
 import Credentials from "next-auth/providers/credentials";
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
+  trustHost: true,
   providers: [
     Credentials({
       name: "Credentials",


### PR DESCRIPTION
## Summary
- Adds `trustHost: true` to NextAuth config for Vercel compatibility
- Uses hard navigation (`window.location`) after login instead of client-side `router.push` to ensure the layout fully re-renders with the new session

Fixes the issue where the login page continued to show (with the sidebar) after signing in.

## Test plan
- [ ] Log in on the deployed app — should redirect to balance sheet with sidebar
- [ ] Refreshing the page should keep you logged in

🤖 Generated with [Claude Code](https://claude.com/claude-code)