### PR TITLE
Fix auth middleware for NextAuth v5 cookie format

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,20 +1,13 @@
+import { auth } from "@/lib/auth";
 import { NextResponse } from "next/server";
-import type { NextRequest } from "next/server";
-import { getToken } from "next-auth/jwt";
 
-export async function middleware(request: NextRequest) {
-  const token = await getToken({
-    req: request,
-    secret: process.env.NEXTAUTH_SECRET,
-  });
-
-  if (!token) {
-    const loginUrl = new URL("/login", request.url);
+export default auth((req) => {
+  if (!req.auth) {
+    const loginUrl = new URL("/login", req.url);
     return NextResponse.redirect(loginUrl);
   }
-
   return NextResponse.next();
-}
+});
 
 export const config = {
   matcher: [


### PR DESCRIPTION
## Summary
- Replaces `getToken()` from `next-auth/jwt` (v4 API) with NextAuth v5's `auth()` wrapper in middleware
- NextAuth v5 uses `authjs.session-token` cookie, but `getToken()` looks for `next-auth.session-token`, causing the middleware to always redirect authenticated users back to `/login`

This was the root cause of the login page showing with the sidebar after signing in.

## Test plan
- [ ] Log in → should redirect to balance sheet (no more login page with sidebar)
- [ ] Unauthenticated visits to `/balance-sheet` should redirect to `/login`
- [ ] Refreshing any page while logged in should stay on that page

🤖 Generated with [Claude Code](https://claude.com/claude-code)