### PR TITLE
Add error handling to transaction creation

### DIFF
--- a/src/app/add-transaction/page.tsx
+++ b/src/app/add-transaction/page.tsx
@@ -77,7 +77,8 @@ export default function AddTransactionPage() {
       toast.success("Transaction added");
       router.push("/balance-sheet");
     } else {
-      toast.error("Failed to add transaction");
+      const data = await res.json().catch(() => null);
+      toast.error(data?.error || "Failed to add transaction");
     }
   }
 

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -17,17 +17,25 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const body = await request.json();
-  const id = await createTransaction({
-    TRANSACTION_DATE: body.TRANSACTION_DATE,
-    CHECK_NMBR: body.CHECK_NMBR || "",
-    DESCRIPTION: body.DESCRIPTION,
-    NOTES: body.NOTES || "",
-    MULTI_PART_TRAN_TOTAL: body.MULTI_PART_TRAN_TOTAL || 0,
-    POSTED_FLAG: body.POSTED_FLAG || 0,
-    TRAN_TYPE: body.TRAN_TYPE,
-    DEBIT: body.DEBIT || 0,
-    CREDIT: body.CREDIT || 0,
-  });
-  return NextResponse.json({ id }, { status: 201 });
+  try {
+    const body = await request.json();
+    const id = await createTransaction({
+      TRANSACTION_DATE: body.TRANSACTION_DATE,
+      CHECK_NMBR: body.CHECK_NMBR || "",
+      DESCRIPTION: body.DESCRIPTION,
+      NOTES: body.NOTES || "",
+      MULTI_PART_TRAN_TOTAL: body.MULTI_PART_TRAN_TOTAL || 0,
+      POSTED_FLAG: body.POSTED_FLAG || 0,
+      TRAN_TYPE: body.TRAN_TYPE,
+      DEBIT: body.DEBIT || 0,
+      CREDIT: body.CREDIT || 0,
+    });
+    return NextResponse.json({ id }, { status: 201 });
+  } catch (error) {
+    console.error("Create transaction error:", error);
+    return NextResponse.json(
+      { error: String(error) },
+      { status: 500 }
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- Wrap the POST `/api/transactions` handler in try/catch so database errors are captured, logged, and returned as JSON
- Update the add-transaction form to display the actual server error in the toast instead of a generic "Failed to add transaction" message

## Test plan
- [ ] Trigger a transaction write failure and verify the real error message appears in the toast
- [ ] Confirm successful transactions still work (toast + redirect to balance sheet)
- [ ] Check server logs for `console.error` output on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)