### PR TITLE
Add mobile sidebar trigger for responsive navigation

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { SessionProvider } from "next-auth/react";
-import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
+import { SidebarProvider, SidebarInset, SidebarTrigger } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/app-sidebar";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -41,7 +41,11 @@ export default async function RootLayout({
               <SidebarProvider>
                 <AppSidebar />
                 <SidebarInset>
-                  <main className="flex-1 p-6">{children}</main>
+                  <header className="flex md:hidden h-14 shrink-0 items-center gap-2 border-b bg-white px-4">
+                    <SidebarTrigger className="size-9" />
+                    <span className="text-sm font-semibold">Serrano Budget</span>
+                  </header>
+                  <div className="flex-1 p-6">{children}</div>
                 </SidebarInset>
               </SidebarProvider>
             ) : (

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -22,6 +22,7 @@ import {
   SidebarMenuItem,
   SidebarFooter,
   SidebarSeparator,
+  useSidebar,
 } from "@/components/ui/sidebar";
 import {
   AlertDialog,
@@ -61,6 +62,7 @@ const navItems = [
 
 export function AppSidebar() {
   const pathname = usePathname();
+  const { setOpenMobile } = useSidebar();
 
   async function handleDeleteLast() {
     const res = await fetch("/api/transactions/last", { method: "DELETE" });
@@ -99,7 +101,7 @@ export function AppSidebar() {
                     isActive={pathname === item.href}
                     className="py-3 text-[14px] font-bold border-t border-[#00094D] border-b border-b-[#1A2876]"
                   >
-                    <Link href={item.href}>
+                    <Link href={item.href} onClick={() => setOpenMobile(false)}>
                       <item.icon className="h-4 w-4" />
                       <span>{item.title}</span>
                     </Link>


### PR DESCRIPTION
On screens below 768px, a header bar with a menu icon now appears, opening the sidebar as a slide-in drawer. Nav links close the drawer on selection.