### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/KSerrano88/SerranoBudget/security/code-scanning/1](https://github.com/KSerrano88/SerranoBudget/security/code-scanning/1)

In general, the problem is fixed by adding an explicit `permissions` block to the workflow (at the root level or per job) that grants only the minimal access the job requires. For a simple test workflow that only checks out code and runs `npm` commands, read access to repository contents is sufficient; no write permissions are needed.

The best way to fix this without changing functionality is to add a root-level `permissions` block after the `name:` line (or before `jobs:`) specifying `contents: read`. This will apply to all jobs in the workflow that do not override `permissions`. Concretely, in `.github/workflows/test.yml`, add:

```yml
permissions:
  contents: read
```

between line 1 (`name: Tests`) and line 3 (`on:`). No imports, methods, or other definitions are required; this is a pure YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
